### PR TITLE
Fixes for the  CompositeFurnaceClassLoader

### DIFF
--- a/plugins/org.jboss.tools.forge.core/src/org/jboss/tools/forge/core/furnace/FurnaceProvider.java
+++ b/plugins/org.jboss.tools.forge.core/src/org/jboss/tools/forge/core/furnace/FurnaceProvider.java
@@ -80,8 +80,8 @@ public class FurnaceProvider {
       ArrayList<ClassLoader> loaders = new ArrayList<>(repositoryManager.getClassLoaders());
       loaders.add(loader);
       
-      new CompositeFurnaceClassLoader(loaders);
-      Furnace furnace = FurnaceFactory.getInstance(loader);
+      CompositeFurnaceClassLoader compositeLoader = new CompositeFurnaceClassLoader(loaders);
+      Furnace furnace = FurnaceFactory.getInstance(compositeLoader);
       
       /*
        * These native repositories need to be added before extensions

--- a/plugins/org.jboss.tools.forge.core/src/org/jboss/tools/forge/core/internal/furnace/CompositeFurnaceClassLoader.java
+++ b/plugins/org.jboss.tools.forge.core/src/org/jboss/tools/forge/core/internal/furnace/CompositeFurnaceClassLoader.java
@@ -11,7 +11,7 @@ public class CompositeFurnaceClassLoader extends ClassLoader
 
    public CompositeFurnaceClassLoader(List<ClassLoader> loaders)
    {
-      loaders.addAll(loaders);
+      this.loaders.addAll(loaders);
    }
 
    @Override


### PR DESCRIPTION
This fixes some issues with the CompositeFurnaceClassLoader but there is still an issue to address. Some classes like the FurnaceImpl exist in both the default class loader and the secondary class loader provided via the extension point. It would seem the version of the FurnaceImpl class in the two different class loaders is different and causes a no method found exception.

My best guess this is caused by the dysfunctional versioning of the Forge plugin where the plugins are not all depending on the most current versions of themselves.

---

!ENTRY org.jboss.tools.forge.core 4 1 2014-05-30 10:10:00.873
!MESSAGE Error logged from Forge Core Plugin: 
!STACK 0
java.lang.NoSuchMethodException: org.jboss.forge.furnace.impl.FurnaceImpl.addRepository(org.jboss.forge.furnace.repositories.AddonRepositoryMode, java.io.File)
    at java.lang.Class.getMethod(Class.java:1665)
    at org.jboss.forge.furnace.proxy.ClassLoaderAdapterCallback$1.getDelegateMethod(ClassLoaderAdapterCallback.java:122)
    at org.jboss.forge.furnace.proxy.ClassLoaderAdapterCallback$1.call(ClassLoaderAdapterCallback.java:95)
    at org.jboss.forge.furnace.util.ClassLoaders.executeIn(ClassLoaders.java:34)
    at org.jboss.forge.furnace.proxy.ClassLoaderAdapterCallback.invoke(ClassLoaderAdapterCallback.java:76)
    at org.jboss.forge.furnace.Furnace_$$_javassist_9604acfa-630d-4b93-a101-470b3cf7ff13.addRepository(Furnace_$$_javassist_9604acfa-630d-4b93-a101-470b3cf7ff13.java)
    at org.jboss.tools.forge.core.furnace.FurnaceProvider.setupFurnace(FurnaceProvider.java:92)
    at org.jboss.tools.forge.core.furnace.FurnaceProvider.access$3(FurnaceProvider.java:74)
    at org.jboss.tools.forge.core.furnace.FurnaceProvider$1.call(FurnaceProvider.java:67)
    at org.jboss.tools.forge.core.furnace.FurnaceProvider$1.call(FurnaceProvider.java:1)
    at org.jboss.forge.furnace.util.ClassLoaders.executeIn(ClassLoaders.java:34)
    at org.jboss.tools.forge.core.furnace.FurnaceProvider.createFurnace(FurnaceProvider.java:45)
    at org.jboss.tools.forge.core.furnace.FurnaceProvider.startFurnace(FurnaceProvider.java:108)
    at org.jboss.tools.forge.core.furnace.FurnaceRuntime.start(FurnaceRuntime.java:81)
    at org.jboss.tools.forge.ui.util.ForgeHelper$1.runInWorkspace(ForgeHelper.java:39)
    at org.eclipse.core.internal.resources.InternalWorkspaceJob.run(InternalWorkspaceJob.java:38)
    at org.eclipse.core.internal.jobs.Worker.run(Worker.java:54)
