### PR TITLE
 Utility classes should not have public constructors

### DIFF
--- a/plugins/org.jboss.tools.aesh.ui/src/org/jboss/tools/aesh/ui/internal/util/CharacterConstants.java
+++ b/plugins/org.jboss.tools.aesh.ui/src/org/jboss/tools/aesh/ui/internal/util/CharacterConstants.java
@@ -10,6 +10,9 @@ import org.jboss.aesh.terminal.Key;
 
 public class CharacterConstants {
 
+	private CharacterConstants() {
+	}
+
 	public static final String START_LINE = toString(Key.HOME);
 	public static final String PREV_CHAR = toString(Key.LEFT);
 	public static final String CTRL_C = toString(Key.CTRL_C);

--- a/plugins/org.jboss.tools.aesh.ui/src/org/jboss/tools/aesh/ui/internal/util/StyleRangeHelper.java
+++ b/plugins/org.jboss.tools.aesh.ui/src/org/jboss/tools/aesh/ui/internal/util/StyleRangeHelper.java
@@ -4,7 +4,10 @@ import org.eclipse.swt.SWT;
 import org.eclipse.swt.custom.StyleRange;
 
 public class StyleRangeHelper {
-	
+
+	private StyleRangeHelper() {
+	}
+
 	public static StyleRange updateStyleRange(StyleRange styleRange) {
 		if (styleRange.fontStyle == SWT.NORMAL) {
 			styleRange.font = FontManager.INSTANCE.getDefault();

--- a/plugins/org.jboss.tools.forge.core/src/org/jboss/tools/forge/core/internal/process/ForgeLaunchHelper.java
+++ b/plugins/org.jboss.tools.forge.core/src/org/jboss/tools/forge/core/internal/process/ForgeLaunchHelper.java
@@ -29,7 +29,10 @@ import org.osgi.framework.Bundle;
 
 
 public class ForgeLaunchHelper {
-	
+
+	private ForgeLaunchHelper() {
+	}
+
 	private static final String ID_FORGE_PROCESS_FACTORY = "org.jboss.tools.forge.core.process.ForgeProcessFactory";
 
 	private static final ILaunchManager LAUNCH_MANAGER = DebugPlugin.getDefault().getLaunchManager();

--- a/plugins/org.jboss.tools.forge.core/src/org/jboss/tools/forge/core/util/ProjectTools.java
+++ b/plugins/org.jboss.tools.forge.core/src/org/jboss/tools/forge/core/util/ProjectTools.java
@@ -24,6 +24,9 @@ import org.eclipse.m2e.core.project.ProjectImportConfiguration;
 
 public class ProjectTools {
 
+	private	 ProjectTools() {
+	}
+
 	public static void updateProjectConfiguration(final IProject project) {		
 	    Job job = new WorkspaceJob("Updating project configuration") {
 	        public IStatus runInWorkspace(IProgressMonitor monitor) {

--- a/plugins/org.jboss.tools.forge.ui.notifications/src/org/jboss/tools/forge/ui/notifications/internal/NotificationHelper.java
+++ b/plugins/org.jboss.tools.forge.ui.notifications/src/org/jboss/tools/forge/ui/notifications/internal/NotificationHelper.java
@@ -10,7 +10,10 @@ import org.eclipse.swt.widgets.Display;
 import org.eclipse.swt.widgets.Shell;
 
 public class NotificationHelper {
-	
+
+	private NotificationHelper() {
+	}
+
 	private static class FadeInRunnable implements Runnable {
 		private Shell shell;
 		private int currentAlpha = 0;

--- a/plugins/org.jboss.tools.forge.ui/src/org/jboss/tools/forge/ui/internal/commands/ForgeCommandPostProcessorHelper.java
+++ b/plugins/org.jboss.tools.forge.ui/src/org/jboss/tools/forge/ui/internal/commands/ForgeCommandPostProcessorHelper.java
@@ -21,7 +21,10 @@ import org.eclipse.ui.IWorkbenchWindow;
 import org.eclipse.ui.PlatformUI;
 
 public class ForgeCommandPostProcessorHelper {
-	
+
+	private ForgeCommandPostProcessorHelper() {
+	}
+
 	public static Map<String, String> getCommandDetails(String commandString) {
 		Map<String, String> result  = new HashMap<String, String>();
 		int ec = commandString.indexOf(" EC: ");

--- a/plugins/org.jboss.tools.forge.ui/src/org/jboss/tools/forge/ui/internal/ext/database/ConnectionProfileUtil.java
+++ b/plugins/org.jboss.tools.forge.ui/src/org/jboss/tools/forge/ui/internal/ext/database/ConnectionProfileUtil.java
@@ -32,6 +32,9 @@ import org.eclipse.datatools.connectivity.drivers.jdbc.IJDBCDriverDefinitionCons
  */
 public class ConnectionProfileUtil {
 
+	private	 ConnectionProfileUtil() {
+	}
+
 	public static String getDriverDefinitionId(IConnectionProfile profile) {
 		if (profile == null) {
 			return null;

--- a/plugins/org.jboss.tools.forge.ui/src/org/jboss/tools/forge/ui/internal/ext/quickaccess/CamelUtil.java
+++ b/plugins/org.jboss.tools.forge.ui/src/org/jboss/tools/forge/ui/internal/ext/quickaccess/CamelUtil.java
@@ -17,6 +17,9 @@ import java.util.List;
  */
 public class CamelUtil {
 
+	private CamelUtil() {
+	}
+
 	/**
 	 * Returns a lowercase string consisting of all initials of the words in the
 	 * given String. Words are separated by whitespace and other special

--- a/plugins/org.jboss.tools.forge.ui/src/org/jboss/tools/forge/ui/internal/util/IDEUtils.java
+++ b/plugins/org.jboss.tools.forge.ui/src/org/jboss/tools/forge/ui/internal/util/IDEUtils.java
@@ -32,6 +32,9 @@ import org.jboss.tools.forge.ui.internal.ForgeUIPlugin;
 
 public class IDEUtils {
 
+	private IDEUtils() {
+	}
+
 	public static void openFileInEditor(IFileStore fileStore, boolean activate) {
 		try {
 			IWorkbenchPage workbenchPage = getActiveWorkbenchPage();

--- a/plugins/org.jboss.tools.forge.ui/src/org/jboss/tools/forge/ui/util/ForgeHelper.java
+++ b/plugins/org.jboss.tools.forge.ui/src/org/jboss/tools/forge/ui/util/ForgeHelper.java
@@ -32,7 +32,10 @@ import org.jboss.tools.forge.ui.internal.ext.importer.ImportEclipseProjectListen
 import org.jboss.tools.forge.ui.internal.part.ForgeConsoleView;
 
 public class ForgeHelper {
-	
+
+	private ForgeHelper() {
+	}
+
 	public static void start(ForgeRuntime runtime) {
 		createStartRuntimeJob(runtime).schedule();
 	}


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S1118 - “Utility classes should not have public constructors ”. You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S1118
Please let me know if you have any questions.
Ayman Abdelghany.