### PR TITLE
Synchronized classes Vector, Hashtable, Stack and StringBuffer should not be used

### DIFF
--- a/plugins/org.jboss.tools.aesh.ui/src/org/jboss/tools/aesh/ui/internal/util/CharacterConstants.java
+++ b/plugins/org.jboss.tools.aesh.ui/src/org/jboss/tools/aesh/ui/internal/util/CharacterConstants.java
@@ -23,7 +23,7 @@ public class CharacterConstants {
 	
 	private static String toString(Key key) {
 		int[] keyValues = key.getKeyValues();
-		StringBuffer buffer = new StringBuffer(keyValues.length);
+		StringBuilder buffer = new StringBuilder(keyValues.length);
 		for (int i : keyValues) {
 			buffer.append((char)i);
 		}

--- a/plugins/org.jboss.tools.forge.core/src/org/jboss/tools/forge/core/internal/process/ForgeLaunchHelper.java
+++ b/plugins/org.jboss.tools.forge.core/src/org/jboss/tools/forge/core/internal/process/ForgeLaunchHelper.java
@@ -106,14 +106,14 @@ public class ForgeLaunchHelper {
 	}
 	
 	private static String createProgramArguments(String location) {
-		StringBuffer buffer = new StringBuffer();
+		StringBuilder buffer = new StringBuilder();
 		buffer.append(createJBossModulesPathArgument(location)).append(' ');
 		buffer.append("org.jboss.forge");
 		return buffer.toString();
 	}
 	
 	private static String createJBossModulesPathArgument(String location) {
-		StringBuffer buffer = new StringBuffer();
+		StringBuilder buffer = new StringBuilder();
 		buffer.append(getMainModulesLocation(location)).append(File.pathSeparator);
 		buffer.append(getUserModulesLocation()).append(File.pathSeparator);
 		buffer.append(getExtraModulesLocation());
@@ -161,7 +161,7 @@ public class ForgeLaunchHelper {
 	}
 	
 	private static String createVmArguments(String location) {
-		StringBuffer buffer = new StringBuffer();
+		StringBuilder buffer = new StringBuilder();
 		buffer.append(getVmArgumentPrefs());
 		buffer.append("-Dforge.home=").append(encloseWithDoubleQuotesIfNeeded(location)).append(' ');
 		buffer.append("-Dforge.shell.colorEnabled=true").append(' ');

--- a/plugins/org.jboss.tools.forge.ui/src/org/jboss/tools/forge/ui/internal/ext/quickaccess/CamelUtil.java
+++ b/plugins/org.jboss.tools.forge.ui/src/org/jboss/tools/forge/ui/internal/ext/quickaccess/CamelUtil.java
@@ -28,7 +28,7 @@ public class CamelUtil {
 	 *         the given string.
 	 */
 	public static String getCamelCase(String s) {
-		StringBuffer result = new StringBuffer();
+		StringBuilder result = new StringBuilder();
 		if (s.length() > 0) {
 			int index = 0;
 			while (index != -1) {


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S1149 - “Synchronized classes Vector, Hashtable, Stack and StringBuffer should not be used ”. You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S1149
Please let me know if you have any questions.
Ayman Abdelghany.