### PR TITLE
Simplify the generics declaration by using the diamond operator ("<>") to reduce the verbosity of generics code.

### DIFF
--- a/plugins/org.jboss.tools.aesh.core/src/org/jboss/tools/aesh/core/internal/ansi/CommandType.java
+++ b/plugins/org.jboss.tools.aesh.core/src/org/jboss/tools/aesh/core/internal/ansi/CommandType.java
@@ -39,7 +39,7 @@ public enum CommandType {
 	
 	private static Map<Character, CommandType> getCommandTypeMap() {
 		if (commandTypeMap == null) {
-			commandTypeMap = new HashMap<Character, CommandType>();
+			commandTypeMap = new HashMap<>();
 		}
 		return commandTypeMap;
 	}

--- a/plugins/org.jboss.tools.aesh.example/src/org/jboss/tools/aesh/example/ExampleConsole.java
+++ b/plugins/org.jboss.tools.aesh.example/src/org/jboss/tools/aesh/example/ExampleConsole.java
@@ -78,7 +78,7 @@ public class ExampleConsole extends AbstractConsole {
 	}
 
 	private Prompt createPrompt() {
-		List<TerminalCharacter> chars = new ArrayList<TerminalCharacter>();
+		List<TerminalCharacter> chars = new ArrayList<>();
 		chars.add(new TerminalCharacter('[', new TerminalColor(Color.DEFAULT, Color.BLUE)));
 		chars.add(new TerminalCharacter('t', new TerminalColor(Color.DEFAULT, Color.RED),
 				CharacterType.ITALIC));

--- a/plugins/org.jboss.tools.aesh.ui/src/org/jboss/tools/aesh/ui/internal/util/FontManager.java
+++ b/plugins/org.jboss.tools.aesh.ui/src/org/jboss/tools/aesh/ui/internal/util/FontManager.java
@@ -26,7 +26,7 @@ public class FontManager {
 	private static Font BOLD;
 	private static Font ITALIC_BOLD;
 	
-	private ArrayList<IPropertyChangeListener> listeners = new ArrayList<IPropertyChangeListener>();
+	private ArrayList<IPropertyChangeListener> listeners = new ArrayList<>();
 	
 	private FontManager() {
 		initializeFonts();

--- a/plugins/org.jboss.tools.forge.core/src/org/jboss/tools/forge/core/internal/ForgeCorePlugin.java
+++ b/plugins/org.jboss.tools.forge.core/src/org/jboss/tools/forge/core/internal/ForgeCorePlugin.java
@@ -32,7 +32,7 @@ public class ForgeCorePlugin extends Plugin {
 	private static ForgeCorePlugin plugin;
 
 	private static Thread shutdownHook;
-	private static List<IProcess> processes = new ArrayList<IProcess>();
+	private static List<IProcess> processes = new ArrayList<>();
 
 	private UsageEventType forgeStartEventType;
 

--- a/plugins/org.jboss.tools.forge.core/src/org/jboss/tools/forge/core/internal/runtime/ForgeAbstractRuntime.java
+++ b/plugins/org.jboss.tools.forge.core/src/org/jboss/tools/forge/core/internal/runtime/ForgeAbstractRuntime.java
@@ -41,7 +41,7 @@ public abstract class ForgeAbstractRuntime implements ForgeRuntime {
 	private MasterStreamListener masterStreamListener = new MasterStreamListener();
 	private CommandResultListener commandResultListener = new CommandResultListener();
 	private PropertyChangeSupport propertyChangeSupport = new PropertyChangeSupport(this);
-	private List<ForgeOutputListener> outputListeners = new ArrayList<ForgeOutputListener>();
+	private List<ForgeOutputListener> outputListeners = new ArrayList<>();
 	
 	
 	public IProcess getProcess() {

--- a/plugins/org.jboss.tools.forge.core/src/org/jboss/tools/forge/core/internal/runtime/ForgeRuntimeManager.java
+++ b/plugins/org.jboss.tools.forge.core/src/org/jboss/tools/forge/core/internal/runtime/ForgeRuntimeManager.java
@@ -15,7 +15,7 @@ import org.jboss.tools.forge.core.runtime.ForgeRuntime;
 public class ForgeRuntimeManager {
 	
 	public static List<ForgeRuntime> getEmbeddedRuntimes() {
-		ArrayList<ForgeRuntime> result = new ArrayList<ForgeRuntime>();
+		ArrayList<ForgeRuntime> result = new ArrayList<>();
 		result.add(FurnaceRuntime.INSTANCE);
 		return result;
 	}

--- a/plugins/org.jboss.tools.forge.core/src/org/jboss/tools/forge/core/preferences/ForgeCorePreferences.java
+++ b/plugins/org.jboss.tools.forge.core/src/org/jboss/tools/forge/core/preferences/ForgeCorePreferences.java
@@ -101,7 +101,7 @@ public class ForgeCorePreferences {
 	}
 
 	private void initializeRuntimes() {
-		runtimes = new ArrayList<ForgeRuntime>();
+		runtimes = new ArrayList<>();
 		runtimes.add(FurnaceRuntime.INSTANCE);
 		addFromXml(getForgeRuntimesPreference());
 		initializeDefaultRuntime();

--- a/plugins/org.jboss.tools.forge.core/src/org/jboss/tools/forge/core/util/ProjectTools.java
+++ b/plugins/org.jboss.tools.forge.core/src/org/jboss/tools/forge/core/util/ProjectTools.java
@@ -60,7 +60,7 @@ public class ProjectTools {
 	}
 	
 	private static Collection<MavenProjectInfo> getProjectToImport(String baseDirPath, String projectName) {
-		ArrayList<MavenProjectInfo> result = new ArrayList<MavenProjectInfo>(1);
+		ArrayList<MavenProjectInfo> result = new ArrayList<>(1);
 		result.add(createMavenProjectInfo(baseDirPath, projectName));
 		return result;
 	}

--- a/plugins/org.jboss.tools.forge.ui.notifications/src/org/jboss/tools/forge/ui/notifications/NotificationDialog.java
+++ b/plugins/org.jboss.tools.forge.ui.notifications/src/org/jboss/tools/forge/ui/notifications/NotificationDialog.java
@@ -37,7 +37,7 @@ public class NotificationDialog {
 		new NotificationDialog(type, title, message).show();
 	}
 
-	private static ArrayList<Shell> ACTIVE_DIALOGS = new ArrayList<Shell>();
+	private static ArrayList<Shell> ACTIVE_DIALOGS = new ArrayList<>();
 
 	private Shell shell;
 	private Composite clientComposite;

--- a/plugins/org.jboss.tools.forge.ui/src/org/jboss/tools/forge/ui/internal/cli/CommandLineListener.java
+++ b/plugins/org.jboss.tools.forge.ui/src/org/jboss/tools/forge/ui/internal/cli/CommandLineListener.java
@@ -61,7 +61,7 @@ import org.jboss.tools.forge.ui.internal.util.IDEUtils;
 public class CommandLineListener implements ProjectListener,
 		CommandExecutionListener {
 
-	private List<Project> projects = new ArrayList<Project>();
+	private List<Project> projects = new ArrayList<>();
 
 	@Override
 	public void postCommandExecuted(UICommand command,
@@ -250,7 +250,7 @@ public class CommandLineListener implements ProjectListener,
 		Viewer viewer = getViewer(remoteSystemView);
 		Object input = viewer.getInput();
 		ArrayList<String> names = createSegmentNames(fileStore);
-		ArrayList<Object> treeSegments = new ArrayList<Object>();
+		ArrayList<Object> treeSegments = new ArrayList<>();
 		for (String name : names) {
 			if (input != null && input instanceof IAdaptable) {
 				ISystemViewElementAdapter adapter = SystemAdapterHelpers
@@ -292,7 +292,7 @@ public class CommandLineListener implements ProjectListener,
 	}
 
 	private ArrayList<String> createSegmentNames(IFileStore fileStore) {
-		ArrayList<String> result = new ArrayList<String>();
+		ArrayList<String> result = new ArrayList<>();
 		while (fileStore.getParent() != null) {
 			result.add(0, fileStore.getName());
 			fileStore = fileStore.getParent();

--- a/plugins/org.jboss.tools.forge.ui/src/org/jboss/tools/forge/ui/internal/commands/CdPostProcessor.java
+++ b/plugins/org.jboss.tools.forge.ui/src/org/jboss/tools/forge/ui/internal/commands/CdPostProcessor.java
@@ -101,7 +101,7 @@ public class CdPostProcessor implements ForgeCommandPostProcessor {
 	}
 	
 	private ArrayList<String> createSegmentNames(IFileStore fileStore) {
-		ArrayList<String> result = new ArrayList<String>();
+		ArrayList<String> result = new ArrayList<>();
 		while (fileStore.getParent() != null) {
 			result.add(0, fileStore.getName());
 			fileStore = fileStore.getParent();
@@ -119,7 +119,7 @@ public class CdPostProcessor implements ForgeCommandPostProcessor {
 		Viewer viewer = getViewer(remoteSystemView);
 		Object input = viewer.getInput();
 		ArrayList<String> names = createSegmentNames(fileStore);
-		ArrayList<Object> treeSegments = new ArrayList<Object>();
+		ArrayList<Object> treeSegments = new ArrayList<>();
 		for (String name : names) {
 			if (input != null && input instanceof IAdaptable) {
 				ISystemViewElementAdapter adapter = SystemAdapterHelpers.getViewAdapter(input);

--- a/plugins/org.jboss.tools.forge.ui/src/org/jboss/tools/forge/ui/internal/commands/ForgeCommandPostProcessorHelper.java
+++ b/plugins/org.jboss.tools.forge.ui/src/org/jboss/tools/forge/ui/internal/commands/ForgeCommandPostProcessorHelper.java
@@ -23,7 +23,7 @@ import org.eclipse.ui.PlatformUI;
 public class ForgeCommandPostProcessorHelper {
 	
 	public static Map<String, String> getCommandDetails(String commandString) {
-		Map<String, String> result  = new HashMap<String, String>();
+		Map<String, String> result  = new HashMap<>();
 		int ec = commandString.indexOf(" EC: ");
 		int crn = commandString.indexOf(" CRN: ");
 		int crt = commandString.indexOf(" CRT: ");

--- a/plugins/org.jboss.tools.forge.ui/src/org/jboss/tools/forge/ui/internal/commands/ForgeCommandProcessorImpl.java
+++ b/plugins/org.jboss.tools.forge.ui/src/org/jboss/tools/forge/ui/internal/commands/ForgeCommandProcessorImpl.java
@@ -30,7 +30,7 @@ public class ForgeCommandProcessorImpl implements ForgeCommandProcessor {
 	
 	private static Map<String, ForgeCommandPostProcessor> getPostProcessors() {
 		if (POST_PROCESSORS == null) {
-			POST_PROCESSORS = new HashMap<String, ForgeCommandPostProcessor>();
+			POST_PROCESSORS = new HashMap<>();
 			POST_PROCESSORS.put("new-project", new NewProjectPostProcessor()); // OK
 			POST_PROCESSORS.put("persistence", new PersistencePostProcessor()); // OK
 			POST_PROCESSORS.put("pick-up", new PickUpPostProcessor()); // OK
@@ -73,7 +73,7 @@ public class ForgeCommandProcessorImpl implements ForgeCommandProcessor {
 	}
 	
 	private Map<String, String> getCommandDetails(String commandString) {
-		Map<String, String> result  = new HashMap<String, String>();
+		Map<String, String> result  = new HashMap<>();
 		int ec = commandString.indexOf(" EC: ");
 		int crn = commandString.indexOf(" CRN: ");
 		int crt = commandString.indexOf(" CRT: ");

--- a/plugins/org.jboss.tools.forge.ui/src/org/jboss/tools/forge/ui/internal/commands/PickUpPostProcessor.java
+++ b/plugins/org.jboss.tools.forge.ui/src/org/jboss/tools/forge/ui/internal/commands/PickUpPostProcessor.java
@@ -122,7 +122,7 @@ public class PickUpPostProcessor implements ForgeCommandPostProcessor {
 	}
 	
 	private ArrayList<String> createSegmentNames(IFileStore fileStore) {
-		ArrayList<String> result = new ArrayList<String>();
+		ArrayList<String> result = new ArrayList<>();
 		while (fileStore.getParent() != null) {
 			result.add(0, fileStore.getName());
 			fileStore = fileStore.getParent();
@@ -140,7 +140,7 @@ public class PickUpPostProcessor implements ForgeCommandPostProcessor {
 		Viewer viewer = getViewer(remoteSystemView);
 		Object input = viewer.getInput();
 		ArrayList<String> names = createSegmentNames(fileStore);
-		ArrayList<Object> treeSegments = new ArrayList<Object>();
+		ArrayList<Object> treeSegments = new ArrayList<>();
 		for (String name : names) {
 			if (input != null && input instanceof IAdaptable) {
 				ISystemViewElementAdapter adapter = SystemAdapterHelpers.getViewAdapter(input);

--- a/plugins/org.jboss.tools.forge.ui/src/org/jboss/tools/forge/ui/internal/commands/RmPostProcessor.java
+++ b/plugins/org.jboss.tools.forge.ui/src/org/jboss/tools/forge/ui/internal/commands/RmPostProcessor.java
@@ -26,7 +26,7 @@ public class RmPostProcessor implements ForgeCommandPostProcessor {
 		int end = par.lastIndexOf(']');
 		if (start == -1 || end == -1) return null;
 		par = par.substring(start + 1, end);
-		ArrayList<String> result = new ArrayList<String>();
+		ArrayList<String> result = new ArrayList<>();
 		StringTokenizer tokenizer = new StringTokenizer(par);
 		while (tokenizer.hasMoreTokens()) {
 			result.add(crn + File.separator + tokenizer.nextToken());

--- a/plugins/org.jboss.tools.forge.ui/src/org/jboss/tools/forge/ui/internal/console/ForgeConsoleManager.java
+++ b/plugins/org.jboss.tools.forge.ui/src/org/jboss/tools/forge/ui/internal/console/ForgeConsoleManager.java
@@ -15,14 +15,14 @@ import org.jboss.tools.forge.core.runtime.ForgeRuntime;
 public enum ForgeConsoleManager {
 	INSTANCE;
 
-	private List<ForgeConsole> consoles = new ArrayList<ForgeConsole>();
+	private List<ForgeConsole> consoles = new ArrayList<>();
 
 	private ForgeConsoleManager() {
 		createConsoles();
 	}
 
 	private void createConsoles() {
-		consoles = new ArrayList<ForgeConsole>();
+		consoles = new ArrayList<>();
 		for (ForgeRuntime runtime : ForgeCorePreferences.INSTANCE.getRuntimes()) {
 			ForgeConsole console = new org.jboss.tools.forge.ui.internal.console.F2Console(
 					runtime);

--- a/plugins/org.jboss.tools.forge.ui/src/org/jboss/tools/forge/ui/internal/document/ForgeDocument.java
+++ b/plugins/org.jboss.tools.forge.ui/src/org/jboss/tools/forge/ui/internal/document/ForgeDocument.java
@@ -52,8 +52,8 @@ public class ForgeDocument extends Document {
 	private StyleRange currentStyleRange;
 	private ForgeOutputListener outputListener;
 	private Map<String, Color> colors;
-	private List<StyleRange> styleRanges = new ArrayList<StyleRange>();
-	private Set<CursorListener> cursorListeners = new HashSet<CursorListener>();
+	private List<StyleRange> styleRanges = new ArrayList<>();
+	private Set<CursorListener> cursorListeners = new HashSet<>();
 
 	public ForgeDocument() {
 		initColors();
@@ -193,7 +193,7 @@ public class ForgeDocument extends Document {
 	}
 
 	private void initColors() {
-		colors = new HashMap<String, Color>();
+		colors = new HashMap<>();
 		colors.put("30", new Color(Display.getDefault(), 0, 0, 0));
 		colors.put("31", new Color(Display.getDefault(), 0xFF, 0, 0));
 		colors.put("32", new Color(Display.getDefault(), 0, 0xFF, 0));

--- a/plugins/org.jboss.tools.forge.ui/src/org/jboss/tools/forge/ui/internal/ext/autocomplete/InputComponentProposalProvider.java
+++ b/plugins/org.jboss.tools.forge.ui/src/org/jboss/tools/forge/ui/internal/ext/autocomplete/InputComponentProposalProvider.java
@@ -32,7 +32,7 @@ public class InputComponentProposalProvider implements IContentProposalProvider 
 	@SuppressWarnings({ "unchecked", "rawtypes" })
 	@Override
 	public IContentProposal[] getProposals(String contents, int position) {
-		List<IContentProposal> proposals = new ArrayList<IContentProposal>();
+		List<IContentProposal> proposals = new ArrayList<>();
 		for (Object proposal : completer.getCompletionProposals(context,
 				(InputComponent) component, contents)) {
 			if (proposal != null) {

--- a/plugins/org.jboss.tools.forge.ui/src/org/jboss/tools/forge/ui/internal/ext/control/ComboControlBuilder.java
+++ b/plugins/org.jboss.tools.forge.ui/src/org/jboss/tools/forge/ui/internal/ext/control/ComboControlBuilder.java
@@ -125,7 +125,7 @@ public class ComboControlBuilder extends ControlBuilder<Combo> {
 	}
 
 	private void updateValueChoices(Combo combo, UISelectOne<Object> selectOne) {
-		List<String> newItems = new ArrayList<String>();
+		List<String> newItems = new ArrayList<>();
 		Iterable<Object> valueChoices = selectOne.getValueChoices();
 		Converter<Object, String> converter = getConverter(selectOne);
 		if (valueChoices != null) {

--- a/plugins/org.jboss.tools.forge.ui/src/org/jboss/tools/forge/ui/internal/ext/control/JavaPackageChooserControlBuilder.java
+++ b/plugins/org.jboss.tools.forge.ui/src/org/jboss/tools/forge/ui/internal/ext/control/JavaPackageChooserControlBuilder.java
@@ -51,7 +51,7 @@ public class JavaPackageChooserControlBuilder extends AbstractTextButtonControl 
 				public Iterable<Object> getCompletionProposals(
 						UIContext context, InputComponent<?, Object> input,
 						String value) {
-					Set<Object> proposals = new TreeSet<Object>();
+					Set<Object> proposals = new TreeSet<>();
 					try {
 						for (IPackageFragment pkg : selectedProject
 								.getPackageFragments()) {

--- a/plugins/org.jboss.tools.forge.ui/src/org/jboss/tools/forge/ui/internal/ext/control/many/CheckboxTableControlBuilder.java
+++ b/plugins/org.jboss.tools.forge.ui/src/org/jboss/tools/forge/ui/internal/ext/control/many/CheckboxTableControlBuilder.java
@@ -202,7 +202,7 @@ public class CheckboxTableControlBuilder extends ControlBuilder<Table> {
 		Iterable<Object> valueChoices = selectMany.getValueChoices();
 		if (valueChoices == null)
 			return;
-		List<String> newItems = new ArrayList<String>();
+		List<String> newItems = new ArrayList<>();
 		Converter<Object, String> converter = getConverter(selectMany);
 		for (Object choice : valueChoices) {
 			String itemLabel = converter.convert(choice);

--- a/plugins/org.jboss.tools.forge.ui/src/org/jboss/tools/forge/ui/internal/ext/database/ConnectionProfileManagerImpl.java
+++ b/plugins/org.jboss.tools.forge.ui/src/org/jboss/tools/forge/ui/internal/ext/database/ConnectionProfileManagerImpl.java
@@ -45,7 +45,7 @@ public class ConnectionProfileManagerImpl implements ConnectionProfileManager {
 	public Map<String, ConnectionProfile> loadConnectionProfiles() {
 		IConnectionProfile[] connectionProfiles = ProfileManager.getInstance()
 				.getProfiles();
-		Map<String, ConnectionProfile> result = new LinkedHashMap<String, ConnectionProfile>();
+		Map<String, ConnectionProfile> result = new LinkedHashMap<>();
 		for (IConnectionProfile currentProfile : connectionProfiles) {
 			ConnectionProfile profile = new ConnectionProfile();
 			String profileName = currentProfile.getName();

--- a/plugins/org.jboss.tools.forge.ui/src/org/jboss/tools/forge/ui/internal/ext/importer/ImportEclipseProjectListener.java
+++ b/plugins/org.jboss.tools.forge.ui/src/org/jboss/tools/forge/ui/internal/ext/importer/ImportEclipseProjectListener.java
@@ -28,7 +28,7 @@ public enum ImportEclipseProjectListener implements ProjectListener,
 
 	INSTANCE;
 
-	private Set<Project> projects = new HashSet<Project>();
+	private Set<Project> projects = new HashSet<>();
 
 	@Override
 	public void projectCreated(Project project) {

--- a/plugins/org.jboss.tools.forge.ui/src/org/jboss/tools/forge/ui/internal/ext/importer/ProjectImporter.java
+++ b/plugins/org.jboss.tools.forge.ui/src/org/jboss/tools/forge/ui/internal/ext/importer/ProjectImporter.java
@@ -91,7 +91,7 @@ public class ProjectImporter {
 	}
 
 	private Collection<MavenProjectInfo> getProjectToImport() {
-		ArrayList<MavenProjectInfo> result = new ArrayList<MavenProjectInfo>(1);
+		ArrayList<MavenProjectInfo> result = new ArrayList<>(1);
 		result.add(createMavenProjectInfo());
 		return result;
 	}

--- a/plugins/org.jboss.tools.forge.ui/src/org/jboss/tools/forge/ui/internal/ext/quickaccess/CamelUtil.java
+++ b/plugins/org.jboss.tools.forge.ui/src/org/jboss/tools/forge/ui/internal/ext/quickaccess/CamelUtil.java
@@ -51,7 +51,7 @@ public class CamelUtil {
 	 * @return an array of length start
 	 */
 	public static int[][] getCamelCaseIndices(String s, int start, int length) {
-		List<int[]> result = new ArrayList<int[]>();
+		List<int[]> result = new ArrayList<>();
 		int index = 0;
 		while (start > 0) {
 			index = getNextCamelIndex(s, index + 1);

--- a/plugins/org.jboss.tools.forge.ui/src/org/jboss/tools/forge/ui/internal/ext/quickaccess/impl/ForgeQuickAccessProvider.java
+++ b/plugins/org.jboss.tools.forge.ui/src/org/jboss/tools/forge/ui/internal/ext/quickaccess/impl/ForgeQuickAccessProvider.java
@@ -21,7 +21,7 @@ import org.jboss.tools.forge.ui.internal.ext.quickaccess.QuickAccessProvider;
 public class ForgeQuickAccessProvider extends QuickAccessProvider implements
 		Comparable<ForgeQuickAccessProvider> {
 
-	private Map<String, QuickAccessElement> candidates = new HashMap<String, QuickAccessElement>();
+	private Map<String, QuickAccessElement> candidates = new HashMap<>();
 	private String category;
 
 	public ForgeQuickAccessProvider(String category, UIContext context,
@@ -59,7 +59,7 @@ public class ForgeQuickAccessProvider extends QuickAccessProvider implements
 
 	@Override
 	public List<QuickAccessElement> getElements() {
-		return new ArrayList<QuickAccessElement>(candidates.values());
+		return new ArrayList<>(candidates.values());
 	}
 
 	@Override

--- a/plugins/org.jboss.tools.forge.ui/src/org/jboss/tools/forge/ui/internal/jobs/ShowFinalSelectionJob.java
+++ b/plugins/org.jboss.tools.forge.ui/src/org/jboss/tools/forge/ui/internal/jobs/ShowFinalSelectionJob.java
@@ -193,7 +193,7 @@ public class ShowFinalSelectionJob extends ChainedWorkspaceJob {
 		if (viewer == null) return;
 		Object input = viewer.getInput();
 		ArrayList<String> names = createSegmentNames(fileStore);
-		ArrayList<Object> treeSegments = new ArrayList<Object>();
+		ArrayList<Object> treeSegments = new ArrayList<>();
 		for (String name : names) {
 			if (input instanceof IAdaptable) {
 				ISystemViewElementAdapter adapter = SystemAdapterHelpers.getViewAdapter(input);
@@ -231,7 +231,7 @@ public class ShowFinalSelectionJob extends ChainedWorkspaceJob {
 	}
 
 	private ArrayList<String> createSegmentNames(IFileStore fileStore) {
-		ArrayList<String> result = new ArrayList<String>();
+		ArrayList<String> result = new ArrayList<>();
 		while (fileStore.getParent() != null) {
 			result.add(0, fileStore.getName());
 			fileStore = fileStore.getParent();

--- a/plugins/org.jboss.tools.forge.ui/src/org/jboss/tools/forge/ui/internal/part/ForgeConsolePageBook.java
+++ b/plugins/org.jboss.tools.forge.ui/src/org/jboss/tools/forge/ui/internal/part/ForgeConsolePageBook.java
@@ -21,7 +21,7 @@ public class ForgeConsolePageBook extends PageBook {
 	private ForgeConsoleView forgeConsoleView = null;
 	private ForgeConsolePage currentPage = null;
 	private Map<ForgeConsole, ForgeConsolePage> forgeConsoleToPage = 
-			new HashMap<ForgeConsole, ForgeConsolePage>();
+			new HashMap<>();
 
 	public ForgeConsolePageBook(ForgeConsoleView forgeConsoleView, Composite parent) {
 		super(parent, SWT.NONE);

--- a/plugins/org.jboss.tools.forge.ui/src/org/jboss/tools/forge/ui/internal/util/IDEUtils.java
+++ b/plugins/org.jboss.tools.forge.ui/src/org/jboss/tools/forge/ui/internal/util/IDEUtils.java
@@ -76,7 +76,7 @@ public class IDEUtils {
 	private static IFile[] filterNonExistentFiles(IFile[] files) {
  		if (files == null) return null;
  		int length = files.length;
- 		ArrayList<IFile> existentFiles = new ArrayList<IFile>(length);
+ 		ArrayList<IFile> existentFiles = new ArrayList<>(length);
  		for (int i = 0; i < length; i++) {
  			if (files[i].exists())
  				existentFiles.add(files[i]);


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S2293 - “The diamond operator ("<>") should be used ”. You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S2293
Please let me know if you have any questions.
Ayman Abdelghany.