### PR TITLE
 Primitive wrappers should not be instantiated only for "toString" or "compareTo" calls

### DIFF
--- a/plugins/org.jboss.tools.forge.core/src/org/jboss/tools/forge/core/internal/runtime/ForgeAbstractRuntime.java
+++ b/plugins/org.jboss.tools.forge.core/src/org/jboss/tools/forge/core/internal/runtime/ForgeAbstractRuntime.java
@@ -168,7 +168,7 @@ public abstract class ForgeAbstractRuntime implements ForgeRuntime {
 				if (streamMonitor != null) {
 					synchronized(mutex) {
 						try {
-							streamsProxy.write(new Character((char)31).toString() + str + '\n');
+							streamsProxy.write(Character.toString((char)31) + str + '\n');
 						} catch (IOException e) {
 							ForgeCorePlugin.log(e);
 						}

--- a/plugins/org.jboss.tools.forge.ui/src/org/jboss/tools/forge/ui/internal/viewer/F1TextViewer.java
+++ b/plugins/org.jboss.tools.forge.ui/src/org/jboss/tools/forge/ui/internal/viewer/F1TextViewer.java
@@ -26,16 +26,16 @@ import org.jboss.tools.forge.ui.internal.document.ForgeDocument;
 
 public class F1TextViewer extends TextViewer implements ForgeTextViewer {
 
-	private static final String START_LINE = new Character((char)1).toString();
-	private static final String PREV_CHAR = new Character((char)2).toString();
-	private static final String CTRL_C = new Character((char)3).toString();
-	private static final String CTRL_D = new Character((char)4).toString();
-	private static final String END_LINE = new Character((char)5).toString();
-	private static final String NEXT_CHAR = new Character((char)6).toString();
-	private static final String DELETE_PREV_CHAR = new Character((char)8).toString();
-	private static final String PREV_HISTORY = new Character((char)16).toString();
-	private static final String NEXT_HISTORY = new Character((char)14).toString();
-	private static final String DELETE_NEXT_CHAR = new Character((char)127).toString();
+	private static final String START_LINE = Character.toString((char)1);
+	private static final String PREV_CHAR = Character.toString((char)2);
+	private static final String CTRL_C = Character.toString((char)3);
+	private static final String CTRL_D = Character.toString((char)4);
+	private static final String END_LINE = Character.toString((char)5);
+	private static final String NEXT_CHAR = Character(.toString(char)6);
+	private static final String DELETE_PREV_CHAR = Character.toString((char)8);
+	private static final String PREV_HISTORY = Character.toString((char)16);
+	private static final String NEXT_HISTORY = Character.toString((char)14);
+	private static final String DELETE_NEXT_CHAR = Character(.toString(char)127);
 	
 	private static final String FORGE_CONSOLE_FONT = "org.jboss.tools.forge.console.font";
 	


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S2131 - “Primitive wrappers should not be instantiated only for "toString" or "compareTo" calls”. You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S2131
Please let me know if you have any questions.
Ayman Abdelghany.